### PR TITLE
Force the use of stdarg.h

### DIFF
--- a/obm/ObmW/HTML-PSformat.c
+++ b/obm/ObmW/HTML-PSformat.c
@@ -48,26 +48,7 @@
 #include <math.h>
 #include "HTMLP.h"
 
-#ifdef _GNU_SOURCE
-#define USE_STDARG
-#endif
-#if defined(__APPLE__) || (__APPLE_CC__ > 1151) || defined(USE_STDARG)
 #include <stdarg.h>
-#else
-#include <varargs.h>
-
-/* Workaround for our old varargs handling on LinuxPPC systems.
-#if defined(linux) && defined(__powerpc__)
-#undef va_start
-#undef va_alist
-#undef va_dcl
-
-#define va_start(AP) __va_start_common (AP, 1)
-#define va_alist __va_1st_arg
-#define va_dcl register int va_alist; ...
-#endif
-*/
-#endif
 
 #if !defined(__DARWIN__)
 #include <malloc.h>
@@ -191,44 +172,7 @@ static float GetDpi ARG1(HTMLWidget, hw) {
  |
 */
 
-#ifdef BROKEN_SOLARIS_COMPILER_STDARG
-/* "Looks like there's a bug in Sun's C compiler and the stdarg.h use
-   of va_start() in HTML-PSformat.c. Until the SunPro folks can take a
-   look at the problem, the following pre-ANSI code should workaround
-   the problem." */
-static int PSprintf ARG1V(char *,format, ...) {
-        va_dcl
-        va_list args;
-        int     len;
-        char    *s;
-
-        if (PS_size - PS_len < 1024) {
-                PS_size += 1024;
-                if ((s = (char *) realloc(PS_string, PS_size)) == NULL) {
-                        fprintf(stderr, "PSprintf malloc failed\n");
-                        return(EOF);
-                }
-                PS_string = s;
-        }
-        va_start(args);
-        len = vsprintf(PS_string+PS_len, format, args);
-        /* this is a hack to make it work on systems were vsprintf(s,.)
-         * returns s, instead of the len.
-         */
-        if (len != EOF && len != NULL)
-                PS_len += strlen(PS_string+PS_len);
-        va_end(args);
-        return(len);
-}
-#else /* not BROKEN_SOLARIS_COMPILER_STDARG */
-
-#if defined(__APPLE__) || (__APPLE_CC__ > 1151) || defined(USE_STDARG)
 static int PSprintf (char *format, ... )
-#else
-static int PSprintf (format, va_alist)
-char* format;
-va_dcl
-#endif
 {
 	int 	len;
 	char 	*s;
@@ -242,11 +186,7 @@ va_dcl
 		}
 		PS_string = s;
 	}
-#if defined(__APPLE__) || (__APPLE_CC__ > 1151) || defined(USE_STDARG)
 	va_start(args,format);
-#else
-	va_start(args);
-#endif
 	len = vsprintf(PS_string+PS_len, format, args);
 	/* this is a hack to make it work on systems were vsprintf(s,...)
 	 * returns s, instead of the len.
@@ -256,7 +196,6 @@ va_dcl
 	va_end(args);
 	return(len);
 }
-#endif /* not BROKEN_SOLARIS_COMPILER_STDARG */
 
 /*__________________________________________________________________________
  |

--- a/obm/ObmW/Imakefile
+++ b/obm/ObmW/Imakefile
@@ -21,14 +21,6 @@ X11IRAFDIR = ../../
         CCOPTIONS = -traditional-cpp
 #endif
 
-#if ((GccMajorVersion == 3) && (GccMinorVersion >= 1))
-        CCOPTIONS = -DUSE_STDARG
-#else
-        CCOPTIONS =
-#endif
-
-
-
 HEADERS = \
 	Arrow.h ArrowP.h Board.h BoardP.h Button.h ButtonP.h \
 	Common.h CommonP.h Converters.h DrawingArea.h DrawingAreaP.h \

--- a/obm/Tcl/Imakefile
+++ b/obm/Tcl/Imakefile
@@ -48,7 +48,7 @@ XCOMM - The following are for SunSoft/Solaris
   EXTRA_LDOPTIONS = -xildoff
       GCC_FLAGS = 
        AC_FLAGS = -DNO_GETWD=1 -DNO_WAIT3=1 -DHAVE_UNISTD_H=1 \
-		  -DNO_UNION_WAIT=1 -DNEED_MATHERR=1 -DUSE_STDARG
+		  -DNO_UNION_WAIT=1 -DNEED_MATHERR=1
     COMPAT_OBJS = tclMtherr.o
 #else
 
@@ -104,7 +104,7 @@ XCOMM - The following are for AIX on Rs/6000
 #else
 #if defined(cygwinArchitecture)
 
-      GCC_FLAGS = -DUSE_STDARG
+      GCC_FLAGS =
        AC_FLAGS = -DHAVE_UNISTD_H=1 -DNO_UNION_WAIT=1 -DNO_STDLIB_H=1
     COMPAT_OBJS =
 #else
@@ -126,15 +126,8 @@ XCOMM - The following are for AIX on Rs/6000
 
 
 # Platform flags.
-#if ((GccMajorVersion == 3) &&  (GccMinorVersion >= 1))
-       PL_FLAGS = -DUSE_STDARG
-#else
 #if ((GccMajorVersion == 4))
-       PL_FLAGS = -DUSE_STDARG
       CPP_FLAGS = -traditional-cpp
-#else
-       PL_FLAGS =
-#endif
 #endif
 
 

--- a/obm/Tcl/tcl.h
+++ b/obm/Tcl/tcl.h
@@ -468,11 +468,7 @@ EXTERN int		Tcl_AsyncInvoke _ANSI_ARGS_((Tcl_Interp *interp,
 EXTERN void		Tcl_AppendElement _ANSI_ARGS_((Tcl_Interp *interp,
 			    char *string));
 #ifdef ELLIPSES
-#ifdef USE_STDARG
 EXTERN void		Tcl_AppendResult _ANSI_ARGS_((Tcl_Interp *interp, ...));
-#else
-EXTERN void		Tcl_AppendResult _ANSI_ARGS_(VARARGS);
-#endif
 #endif
 EXTERN int		Tcl_AppInit _ANSI_ARGS_((Tcl_Interp *interp));
 EXTERN void		Tcl_AddErrorInfo _ANSI_ARGS_((Tcl_Interp *interp,
@@ -589,11 +585,7 @@ EXTERN int		Tcl_ScanElement _ANSI_ARGS_((char *string,
 EXTERN int		Tcl_SetCommandInfo _ANSI_ARGS_((Tcl_Interp *interp,
 			    char *cmdName, Tcl_CmdInfo *infoPtr));
 #ifdef ELLIPSES
-#ifdef USE_STDARG
 EXTERN void		Tcl_SetErrorCode _ANSI_ARGS_((Tcl_Interp *interp, ...));
-#else
-EXTERN void		Tcl_SetErrorCode _ANSI_ARGS_(VARARGS);
-#endif
 #endif
 EXTERN int		Tcl_SetRecursionLimit _ANSI_ARGS_((Tcl_Interp *interp,
 			    int depth));
@@ -631,11 +623,7 @@ EXTERN void		Tcl_UntraceVar2 _ANSI_ARGS_((Tcl_Interp *interp,
 			    char *part1, char *part2, int flags,
 			    Tcl_VarTraceProc *proc, ClientData clientData));
 #ifdef ELLIPSES
-#ifdef USE_STDARG
 EXTERN int		Tcl_VarEval _ANSI_ARGS_((Tcl_Interp *iPtr, ...));
-#else
-EXTERN int		Tcl_VarEval _ANSI_ARGS_(VARARGS);
-#endif
 #endif
 EXTERN ClientData	Tcl_VarTraceInfo _ANSI_ARGS_((Tcl_Interp *interp,
 			    char *varName, int flags,

--- a/obm/Tcl/tclBasic.c
+++ b/obm/Tcl/tclBasic.c
@@ -1239,21 +1239,7 @@ Tcl_AddErrorInfo(interp, message)
  */
 	/* VARARGS2 */ /* ARGSUSED */
 int
-#ifdef USE_STDARG
 Tcl_VarEval(Tcl_Interp *iPtr, ...)
-#else
-
-#ifndef lint
-Tcl_VarEval(va_alist)
-#else
-Tcl_VarEval(iPtr, p, va_alist)
-    Tcl_Interp *iPtr;		/* Interpreter in which to execute command. */
-    char *p;			/* One or more strings to concatenate,
-				 * terminated with a NULL string. */
-#endif
-
-    va_dcl
-#endif
 {
     va_list argList;
 
@@ -1271,12 +1257,7 @@ Tcl_VarEval(iPtr, p, va_alist)
      * space.
      */
 
-#ifdef USE_STDARG
     va_start(argList, iPtr);
-#else
-    va_start(argList);
-    (void) va_arg(argList, Tcl_Interp *);
-#endif
     spaceAvl = FIXED_SIZE;
     spaceUsed = 0;
     cmd = fixedSpace;

--- a/obm/Tcl/tclInt.h
+++ b/obm/Tcl/tclInt.h
@@ -65,26 +65,7 @@
 #include <string.h>
 #endif
 
-/*
-*/
-#if defined(__DARWIN__) || defined(USE_STDARG)
 #include <stdarg.h>
-#else
-#include <varargs.h>
-#endif
-
-/* Workaround for our old varargs handling on LinuxPPC systems.
-#if defined(linux) && defined(__powerpc__)
-#undef va_start
-#undef va_alist
-#undef va_dcl
-
-#define va_start(AP) __va_start_common (AP, 1)
-#define va_alist __va_1st_arg
-#define va_dcl register int va_alist; ...
-#endif
-*/
-
 
 /*
  * At present (12/91) not all stdlib.h implementations declare strtod.

--- a/obm/Tcl/tclUtil.c
+++ b/obm/Tcl/tclUtil.c
@@ -1042,22 +1042,7 @@ Tcl_SetResult(interp, string, freeProc)
 
 	/* VARARGS2 */
 void
-#ifdef USE_STDARG
 Tcl_AppendResult(Tcl_Interp *interp, ...)
-#else
-#ifndef lint
-Tcl_AppendResult(va_alist)
-#else
-void
-	/* VARARGS2 */ /* ARGSUSED */
-Tcl_AppendResult(interp, p, va_alist)
-    Tcl_Interp *interp;		/* Interpreter whose result is to be
-				 * extended. */
-    char *p;			/* One or more strings to add to the
-				 * result, terminated with NULL. */
-#endif
-    va_dcl
-#endif
 {
     va_list argList;
     Interp *iPtr = (Interp *) interp;
@@ -1069,12 +1054,7 @@ Tcl_AppendResult(interp, p, va_alist)
      * needed.
      */
 
-#ifdef USE_STDARG
     va_start(argList, interp);
-#else
-    va_start(argList);
-    (void) va_arg(argList, Interp *);
-#endif
     newSpace = 0;
     while (1) {
 	string = va_arg(argList, char *);
@@ -1101,12 +1081,7 @@ Tcl_AppendResult(interp, p, va_alist)
      * them into the buffer.
      */
 
-#ifdef USE_STDARG
     va_start(argList, interp);
-#else
-    va_start(argList);
-    (void) va_arg(argList, Interp *);
-#endif
     while (1) {
 	string = va_arg(argList, char *);
 	if (string == NULL) {
@@ -1308,22 +1283,7 @@ Tcl_ResetResult(interp)
  */
 	/* VARARGS2 */
 void
-#ifdef USE_STDARG
 Tcl_SetErrorCode(Tcl_Interp *interp, ...)
-#else
-#ifndef lint
-Tcl_SetErrorCode(va_alist)
-#else
-void
-	/* VARARGS2 */ /* ARGSUSED */
-Tcl_SetErrorCode(interp, p, va_alist)
-    Tcl_Interp *interp;		/* Interpreter whose errorCode variable is
-				 * to be set. */
-    char *p;			/* One or more elements to add to errorCode,
-				 * terminated with NULL. */
-#endif
-    va_dcl
-#endif
 {
     va_list argList;
     char *string;
@@ -1335,11 +1295,7 @@ Tcl_SetErrorCode(interp, p, va_alist)
      * $errorCode as list elements.
      */
 
-#ifdef USE_STDARG
     va_start(argList, interp);
-#else
-    va_start(argList);
-#endif
     (void) va_arg(argList, Tcl_Interp *);
     flags = TCL_GLOBAL_ONLY | TCL_LIST_ELEMENT;
     while (1) {


### PR DESCRIPTION
Varargs (`varargs.h`) are old-style, pre-ISO-C, non-POSIX, and not used anymore. This PR removes all references to it.