### PR TITLE
Fix a small glitch in xaw3d/Imakefile

### DIFF
--- a/xaw3d/Imakefile
+++ b/xaw3d/Imakefile
@@ -138,7 +138,8 @@ SRCS = \
 	AsciiText.c \
 	Box.c \
 	Command.c \
-	Dialog.c \ Form.c \
+	Dialog.c \
+	Form.c \
 	Grip.c \
 	Label.c \
 	List.c \


### PR DESCRIPTION
There was a protected space instead of a newline, which leads to a wrong file name ` Form.c`.