### PR TITLE
Fix size of overlay cmap

### DIFF
--- a/obm/ObmW/GtermCnv.c
+++ b/obm/ObmW/GtermCnv.c
@@ -282,7 +282,7 @@ int	border;
 	/* Create the lookup table.
 	*/
 	bzero (global_lut, sizeof(long) * MAX_SZCMAP);
-	for (i=0; i < MAX_SZCMAP; i++) {
+	for (i=0; i < MAX_SZCMAP - SZ_STATIC_CMAP; i++) {
 	    pv = global_cmap[i + SZ_STATIC_CMAP];
 
 	    /* Get the color components.

--- a/obm/ObmW/GtermP.h
+++ b/obm/ObmW/GtermP.h
@@ -14,7 +14,7 @@
 #define	SZ_NUMBER		64
 #define	SZ_STATIC_CMAP		10		/* bg+fg+NColors              */
 #define	SZ_DYNAMIC_CMAP		201		/* bg+fg+NColors              */
-#define	SZ_OVERLAY_CMAP		18		/* bg+fg+NColors              */
+#define	SZ_OVERLAY_CMAP		17		/* bg+fg+NColors              */
 #define MAX_SZCMAP		256		/* max size colormap          */
 #define	DEF_MAXCOLORS		216		/* max dynamic colors         */
 #define MAX_WMWIN		32		/* max WM colormaps           */


### PR DESCRIPTION
There are two read access errors in the intialization of GTerm: First, the `global_cmap` has only `MAX_SZ_CMAP` entries and is therefore accessed outside of the here: https://github.com/iraf-community/x11iraf/blob/d70609cdfad8656ef0b4b6c88c0e5a5a33779339/obm/ObmW/GtermCnv.c#L285-L286

The solution is to restrict the loop to the entries in `global_cmap`.

Second, `static_colors` is defined to have 27 (10 static and 17 overlay) entries, https://github.com/iraf-community/x11iraf/blob/d70609cdfad8656ef0b4b6c88c0e5a5a33779339/obm/ObmW/Gterm.c#L470-L505

However, `SZ_OVERLAY_CMAP` is defined as 18: https://github.com/iraf-community/x11iraf/blob/d70609cdfad8656ef0b4b6c88c0e5a5a33779339/obm/ObmW/GtermP.h#L17

This leads to an access outside of the definition in the initialization: https://github.com/iraf-community/x11iraf/blob/d70609cdfad8656ef0b4b6c88c0e5a5a33779339/obm/ObmW/Gterm.c#L866-L868

Here, `SZ_OVERLAY_CMAP` is decreased by one to fit reality.