### PR TITLE
Install terminfo file into database

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -30,6 +30,7 @@ install: xgterm ximtool xtapemon
 	mkdir -p ${PREFIX}/bin ${PREFIX}/man/man1
 	install -m755 xgterm/xgterm ${PREFIX}/bin
 	install -m755 xgterm/xgterm.man ${PREFIX}/man/man1/xgterm.1
+	tic xgterm/xgterm.terminfo
 	install -m755 ximtool/ximtool ${PREFIX}/bin
 	install -m755 ximtool/ximtool.man ${PREFIX}/man/man1/ximtool.1
 	if [ -x ximtool/clients/ism_wcspix.e ] ; then \

--- a/xgterm/xgterm.terminfo
+++ b/xgterm/xgterm.terminfo
@@ -1,0 +1,4 @@
+# xgterm.terminfo: Terminfo entry source for xgterm
+# compile with "tic xgterm.terminfo"
+xgterm|graphic terminal for IRAF,
+	use=xterm-r5,


### PR DESCRIPTION
This sets the correct environment variable `$TERM` in the terminal and so enables the full graphics.

Fixes #4 

Downstream distributions should use the `-o` option of `tic`, and install the resulting file `x/xgterm` with the package.