### PR TITLE
Use __APPLE__ as machine type predefine for macos X

### DIFF
--- a/obm/Makefile
+++ b/obm/Makefile
@@ -4,7 +4,7 @@ ALL_OBJS = ObmW/[A-Za-z]*.o $(OBJS)
 
 UNAME_S := $(shell uname -s)
 ifeq ($(UNAME_S),Darwin)
-    CFLAGS += -I/usr/X11/include -D__DARWIN__
+    CFLAGS += -I/usr/X11/include
     LDFLAGS += -L/usr/X11/lib
 endif
 

--- a/obm/ObmW/HTML-PSformat.c
+++ b/obm/ObmW/HTML-PSformat.c
@@ -51,7 +51,7 @@
 
 #include <stdarg.h>
 
-#if !defined(__DARWIN__)
+#if !defined(__APPLE__)
 #include <malloc.h>
 #endif
 

--- a/obm/ObmW/Makefile
+++ b/obm/ObmW/Makefile
@@ -7,7 +7,7 @@ OBJS = Arrow.o Board.o Button.o Common.o DrawIString.o DrawString.o	\
 
 UNAME_S := $(shell uname -s)
 ifeq ($(UNAME_S),Darwin)
-    CFLAGS += -I/usr/X11/include -D__DARWIN__
+    CFLAGS += -I/usr/X11/include
     LDFLAGS += -L/usr/X11/lib
 endif
 

--- a/obm/listres/Makefile
+++ b/obm/listres/Makefile
@@ -3,7 +3,7 @@ OBJS = listres.o AllWidgets.o
 CFLAGS += -I.. -I../ObmW
 UNAME_S := $(shell uname -s)
 ifeq ($(UNAME_S),Darwin)
-    CFLAGS += -I/usr/X11/include -D__DARWIN__
+    CFLAGS += -I/usr/X11/include
     LDFLAGS += -L/usr/X11/lib
 endif
 

--- a/obmsh/Makefile
+++ b/obmsh/Makefile
@@ -5,7 +5,7 @@ all: obmsh
 CFLAGS += -I../obm
 UNAME_S := $(shell uname -s)
 ifeq ($(UNAME_S),Darwin)
-    CFLAGS += -I/usr/X11/include -D__DARWIN__
+    CFLAGS += -I/usr/X11/include
     LDFLAGS += -L/usr/X11/lib
 endif
 

--- a/xgterm/Makefile
+++ b/xgterm/Makefile
@@ -6,7 +6,7 @@ all: xgterm
 CFLAGS += -I../obm -DALLOWLOGGING
 UNAME_S := $(shell uname -s)
 ifeq ($(UNAME_S),Darwin)
-    CFLAGS += -I/usr/X11/include -D__DARWIN__
+    CFLAGS += -I/usr/X11/include
     LDFLAGS += -L/usr/X11/lib
 endif
 

--- a/xgterm/main.c
+++ b/xgterm/main.c
@@ -108,7 +108,7 @@ SOFTWARE.
 #define USE_SYSV_SIGHUP
 #endif
 
-#ifdef __DARWIN__
+#ifdef __APPLE__
 #define NEW_GET_PTY
 #define NEW_SPAWN
 #define USE_HANDSHAKE
@@ -1524,7 +1524,7 @@ char *name;
 #ifdef NEW_GET_PTY
 
 
-#ifdef __DARWIN__
+#ifdef __APPLE__
 #define USE_OPENPTY 1
 static int opened_tty = -1;
 #endif
@@ -2565,7 +2565,7 @@ spawn(void)
 		int ptyfd = 0;
 		char *pty_name = 0;
 
-#ifdef __DARWIN__
+#ifdef __APPLE__
  ; 
 #else
 		setpgrp();

--- a/ximtool/Makefile
+++ b/ximtool/Makefile
@@ -9,7 +9,7 @@ all: ximtool clients
 CFLAGS += -I../obm
 UNAME_S := $(shell uname -s)
 ifeq ($(UNAME_S),Darwin)
-    CFLAGS += -I/usr/X11/include -D__DARWIN__
+    CFLAGS += -I/usr/X11/include
     LDFLAGS += -L/usr/X11/lib
 endif
 

--- a/ximtool/iis.c
+++ b/ximtool/iis.c
@@ -170,7 +170,7 @@ register XimDataPtr xim;
 	int keepalive;
 
 
-#if defined (__DARWIN__) || defined(__CYGWIN__)
+#if defined (__APPLE__) || defined(__CYGWIN__)
 	/* On OS X we don't use fifos. */
 	xim->input_fifo = "none";
 	return (NULL);

--- a/xtapemon/Makefile
+++ b/xtapemon/Makefile
@@ -2,7 +2,7 @@ OBJS = classnames.o types.o xtapemon.o
 
 UNAME_S := $(shell uname -s)
 ifeq ($(UNAME_S),Darwin)
-    CFLAGS += -I/usr/X11/include -D__DARWIN__
+    CFLAGS += -I/usr/X11/include -D__APPLE__
     LDFLAGS += -L/usr/X11/lib
 endif
 


### PR DESCRIPTION
`__APPLE__` is predefined, while `__DARWIN__` is not. This simplifies the Makefiles a bit.