### PR TITLE
Remove errornous declaration of time()

### DIFF
--- a/obm/ObmW/GtermImaging.c
+++ b/obm/ObmW/GtermImaging.c
@@ -1388,7 +1388,7 @@ usedef:	    /* Allocate private r/w colors from default colormap. */
 	     * does not yet exist we create one.  Multiple gterm widget
 	     * instances may share the same colormap.
 	     */
-	    long timeval, time();
+	    long timeval;
 	    int shadow;
 
 


### PR DESCRIPTION
`time_t` is *not* (always) a synonym for `long` -- for example not on x32_86. Also, it is not needed to declare time(), since the corresponding header is already included.