### PR TITLE
Add a statement to install terminfo

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,14 +103,16 @@ This will automatically compile all sources and create the executables
 `ximtool/clients/ism_wcspix.e`. The compilation can be tuned by
 setting `CFLAGS` and `LDFLAGS`. If the environment variable
 `OSI_COMPLIANT` is set to `YES`, the build uses only source files that
-are Open Source according.
+are Open Source.
 
 To copy the executables to `/usr/local/bin`, execute as root
 
     # make install
 
 This will also install the manpages to `/usr/local/man/` und the
-terminfo file for xgterm to `/usr/share/terminfo/`.
+required terminfo file for xgterm to `/usr/share/terminfo/`. If you
+don't want to invoke `make install`, you should make sure to run
+`tic xgterm/xgterm.terminfo` to compile and install the terminfo file.
 
 
 ## Other included programs


### PR DESCRIPTION
Without installing terminfo, one may observe problems with ecl history, as it happend in #29. Usually, this is done in the `make
install` step; people may however decide to not run this. 