### PR TITLE
Remove warnings for missing function declarations

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,7 +16,7 @@ matrix:
             - xvfb
       env: OSI_COMPLIANT=YES
     - os: osx
-      osx_image: xcode11.5
+      osx_image: xcode12.3
 
 language: c
 

--- a/obm/gterm.c
+++ b/obm/gterm.c
@@ -2946,6 +2946,7 @@ char **argv;
 	int raster, ctype;
 	Pixmap pixmap;
 	char *s_pixmap;
+	int createPixmap();
 
 	if (argc < 3)
 	    return (TCL_ERROR);

--- a/xgterm/Makefile
+++ b/xgterm/Makefile
@@ -3,7 +3,7 @@ OBJS = button.o charproc.o cursor.o data.o gtermio.o input.o main.o	\
 
 all: xgterm
 
-CFLAGS += -I../obm -DALLOWLOGGING
+CFLAGS += -I../obm -DALLOWLOGGING -Wno-implicit-function-declaration -Wno-implicit-int
 UNAME_S := $(shell uname -s)
 ifeq ($(UNAME_S),Darwin)
     CFLAGS += -I/usr/X11/include


### PR DESCRIPTION
Otherwise, C99 compatible compilers complain about implicit function declarations.

This is quick and dirty, due to the number of functions.
Also, most of the implicit function declarations happen in xgterm, which is anyway taken from the xterm package and should be replaced by a modern version from there at some time.

Fixes #33 