### PR TITLE
Implement DESTDIR feature

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,12 +1,11 @@
 all: xgterm ximtool
 
-PREFIX = /usr/local
+prefix = /usr/local
 
 export TCL_INCLUDE_DIR = /usr/include/tcl
 
 .PHONY: xgterm ximtool xtapemon obmsh
 
-	
 obm/libobm.a:
 	$(MAKE) -C obm
 
@@ -30,12 +29,12 @@ clean:
 	$(MAKE) -C obm clean
 
 install: xgterm ximtool
-	mkdir -p ${PREFIX}/bin ${PREFIX}/man/man1
-	install -m755 xgterm/xgterm ${PREFIX}/bin
-	install -m755 xgterm/xgterm.man ${PREFIX}/man/man1/xgterm.1
+	mkdir -p ${DESTDIR}${prefix}/bin ${DESTDIR}${prefix}/man/man1
+	install -m755 xgterm/xgterm ${DESTDIR}${prefix}/bin
+	install -m755 xgterm/xgterm.man ${DESTDIR}${prefix}/man/man1/xgterm.1
 	tic xgterm/xgterm.terminfo
-	install -m755 ximtool/ximtool ${PREFIX}/bin
-	install -m755 ximtool/ximtool.man ${PREFIX}/man/man1/ximtool.1
+	install -m755 ximtool/ximtool ${DESTDIR}${prefix}/bin
+	install -m755 ximtool/ximtool.man ${DESTDIR}${prefix}/man/man1/ximtool.1
 	if [ -x ximtool/clients/ism_wcspix.e ] ; then \
-	    install -m755 ximtool/clients/ism_wcspix.e ${PREFIX}/bin ; \
+	    install -m755 ximtool/clients/ism_wcspix.e ${DESTDIR}${prefix}/bin ; \
 	fi


### PR DESCRIPTION
This allows to install x11iraf temporarily to a different place from where it will be running.  This important for packaging in Linux distributions.

```shellscript
make install DESTDIR=debian/tmp
```
