### PR TITLE
Make Tcl library configurable

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,6 +3,7 @@ all: xgterm ximtool
 prefix = /usr/local
 
 export TCL_INCLUDE_DIR = /usr/include/tcl
+export TCL_LIB = -ltcl
 
 .PHONY: xgterm ximtool xtapemon obmsh
 

--- a/obm/listres/Makefile
+++ b/obm/listres/Makefile
@@ -12,7 +12,7 @@ all: listres
 listres: $(OBJS)
 	$(CC) $(LDFLAGS) -o $@ $(OBJS) \
 	    -L.. -lobm \
-	    -lXpm -ltcl -lXaw3d -lXmu -lXt -lXext -lX11 -lm
+	    -lXpm $(TCL_LIB) -lXaw3d -lXmu -lXt -lXext -lX11 -lm
 
 clean:
 	rm -f listres $(OBJS)

--- a/obmsh/Makefile
+++ b/obmsh/Makefile
@@ -12,7 +12,7 @@ endif
 obmsh: $(OBJS)
 	$(CC) $(LDFLAGS) -o $@ $(OBJS) \
 	    -L../obm -lobm \
-	    -lXpm -ltcl -lXaw3d -lXmu -lXt -lXext -lX11 -lncurses -lm
+	    -lXpm $(TCL_LIB) -lXaw3d -lXmu -lXt -lXext -lX11 -lncurses -lm
 
 clean:
 	rm -f obmsh $(OBJS)

--- a/xgterm/Makefile
+++ b/xgterm/Makefile
@@ -13,7 +13,7 @@ endif
 xgterm: $(OBJS)
 	$(CC) $(LDFLAGS) -o $@ $(OBJS) \
 	    -L../obm -lobm \
-	    -lXpm -ltcl -lXaw3d -lXmu -lXt -lXext -lX11 -lncurses -lm
+	    -lXpm $(TCL_LIB) -lXaw3d -lXmu -lXt -lXext -lX11 -lncurses -lm
 
 clean:
 	rm -f xgterm $(OBJS)

--- a/ximtool/Makefile
+++ b/ximtool/Makefile
@@ -31,7 +31,7 @@ ximtool.html.h: ximtool.html
 ximtool: $(OBJS)
 	$(CC) $(LDFLAGS) -o $@ $(OBJS) \
 	    -L../obm -lobm \
-	    -lXpm -ltcl -lXaw3d -lXmu -lXt -lXext -lX11 -lncurses -lm
+	    -lXpm $(TCL_LIB) -lXaw3d -lXmu -lXt -lXext -lX11 -lncurses -lm
 
 clients:
 	cd clients && mkpkg || true


### PR DESCRIPTION
On openSUSE, the tcl library is not called `libtcl.so`, but `libtcl8.6.so` without the link to the default `libtcl.so`. In this case, one can still compile with 
```sh
$ make TCL_LIB=-ltcl8.6
```
Reference: [stackoverflow#77644796](https://stackoverflow.com/questions/77643299/unable-to-link-tcl-headers-on-opensuse-15-4/77644796)