### PR TITLE
Fix manpage location

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -30,12 +30,12 @@ clean:
 	$(MAKE) -C obm clean
 
 install: xgterm ximtool
-	mkdir -p ${DESTDIR}${prefix}/bin ${DESTDIR}${prefix}/man/man1
+	mkdir -p ${DESTDIR}${prefix}/bin ${DESTDIR}${prefix}/share/man/man1
 	install -m755 xgterm/xgterm ${DESTDIR}${prefix}/bin
-	install -m755 xgterm/xgterm.man ${DESTDIR}${prefix}/man/man1/xgterm.1
+	install -m755 xgterm/xgterm.man ${DESTDIR}${prefix}/share/man/man1/xgterm.1
 	tic xgterm/xgterm.terminfo
 	install -m755 ximtool/ximtool ${DESTDIR}${prefix}/bin
-	install -m755 ximtool/ximtool.man ${DESTDIR}${prefix}/man/man1/ximtool.1
+	install -m755 ximtool/ximtool.man ${DESTDIR}${prefix}/share/man/man1/ximtool.1
 	if [ -x ximtool/clients/ism_wcspix.e ] ; then \
 	    install -m755 ximtool/clients/ism_wcspix.e ${DESTDIR}${prefix}/bin ; \
 	fi


### PR DESCRIPTION
The manpages are usually installed in `…/share/man`, not in `…/man`.

This is also consistent with the location where IRAF [installs its manpages](https://github.com/iraf-community/iraf/blob/e962213b1d1d386697ea90e123690b1f690a5a30/Makefile#L182-L190).

Ref: [FHS 3.0](https://refspecs.linuxfoundation.org/FHS_3.0/fhs/ch04s11.html#usrsharemanManualPages) (for Linux, couldn't find a reference for for macOS yet)

(Althought, on both Linux and macOS `/usr/local/man` and `/usr/local/share/man` are symlinked together).