### PR TITLE
Use time_t instead of long for time

### DIFF
--- a/obm/ObmW/GtermImaging.c
+++ b/obm/ObmW/GtermImaging.c
@@ -1338,7 +1338,7 @@ usedef:	    /* Allocate private r/w colors from default colormap. */
 	     * does not yet exist we create one.  Multiple gterm widget
 	     * instances may share the same colormap.
 	     */
-	    long timeval;
+	    time_t timeval;
 	    int shadow;
 
 
@@ -1395,7 +1395,7 @@ usedef:	    /* Allocate private r/w colors from default colormap. */
 	     * be loaded by the window manager.
 	     */
 	    shadow = w->gterm.cmapShadow;
-	    timeval = time((long *)NULL);
+	    timeval = time(NULL);
 
 	    if (shadow && (!w->gterm.in_window ||
 		    (timeval - w->gterm.cmapLastShadow > shadow * 1000))) {

--- a/ximtool/eps.c
+++ b/ximtool/eps.c
@@ -1837,7 +1837,7 @@ make_label(void)
         char    hostname[32];
         char    username[32];
         struct  passwd *pw;
-        long    clock;
+        time_t    clock;
 
 
 	bzero (buf, 128);
@@ -1850,7 +1850,7 @@ make_label(void)
         gethostname (hostname, 32);
 #endif
 
-        clock = time(0);
+        clock = time(NULL);
         pw = getpwuid (getuid());
         strcpy (username, pw->pw_name);
         endpwent();

--- a/ximtool/iis.c
+++ b/ximtool/iis.c
@@ -626,7 +626,7 @@ xim_iisio (IoChanPtr chan, int *fd_addr, XtInputId *id_addr)
 		 */
 		unsigned char *ip, iobuf[SZ_IOBUF];
 		int     nbytes, nleft, n, x, y;
-		long    starttime;
+		time_t    starttime;
 
 		/* Get the frame to read from. */
 		xim_setReferenceFrame (chan, decode_frameno (iis.z & 0177777));
@@ -670,11 +670,11 @@ xim_iisio (IoChanPtr chan, int *fd_addr, XtInputId *id_addr)
 		}
 
 		/* Return the data from the frame buffer. */
-		starttime = time(0);
+		starttime = time(NULL);
 		for (nleft=nbytes, ip=iobuf;  nleft > 0;  nleft -= n) {
 		    n = (nleft < SZ_FIFOBUF) ? nleft : SZ_FIFOBUF;
 		    if ((n = chan_write (dataout, ip, n)) <= 0) {
-			if (n < 0 || (time(0) - starttime > IO_TIMEOUT)) {
+			if (n < 0 || (time(NULL) - starttime > IO_TIMEOUT)) {
 			    fprintf (stderr, "XIMTOOL: timeout on write\n");
 			    break;
 			}
@@ -689,7 +689,7 @@ xim_iisio (IoChanPtr chan, int *fd_addr, XtInputId *id_addr)
 		 */
 		unsigned char *op, iobuf[SZ_IOBUF];
 		int     nbytes, nleft, n, x, y;
-		long    starttime;
+		time_t    starttime;
 
 		/* Get the frame to be written into (encoded with a bit for
 		 * each frame, 01 is frame 1, 02 is frame 2, 04 is frame 3,
@@ -703,11 +703,11 @@ xim_iisio (IoChanPtr chan, int *fd_addr, XtInputId *id_addr)
 
 		/* Read the data into the frame buffer.
 		 */
-		starttime = time(0);
+		starttime = time(NULL);
 		for (nleft=nbytes, op=iobuf;  nleft > 0;  nleft -= n) {
 		    n = (nleft < SZ_FIFOBUF) ? nleft : SZ_FIFOBUF;
 		    if ((n = chan_read (datain, op, n)) <= 0) {
-			if (n < 0 || (time(0) - starttime > IO_TIMEOUT)) {
+			if (n < 0 || (time(NULL) - starttime > IO_TIMEOUT)) {
 			    fprintf (stderr, "XIMTOOL: timeout on read\n");
 			    break;
 			}

--- a/ximtool/raster.c
+++ b/ximtool/raster.c
@@ -2738,7 +2738,7 @@ xim_setColormap (
 	    int red, green, blue;
 	    
 	    if (!seed)
-		seed = time(0);
+		seed = time(NULL);
 	    srand (seed++);
 
 	    for (i=0;  i < nelem;  ) {
@@ -2757,7 +2757,7 @@ xim_setColormap (
 	    int red, green, blue;
 	    
 	    if (!seed)
-		seed = time(0);
+		seed = time(NULL);
 	    srand (seed++);
 
 	    for (i=0;  i < nelem;  ) {
@@ -2774,7 +2774,7 @@ xim_setColormap (
 
 	} else if (strncmp (function, "Random", 6) == 0) {
 	    if (!seed)
-		seed = time(0);
+		seed = time(NULL);
 	    srand (seed++);
 	    for (i=0;  i < nelem;  i++) {
 		m_red[i]   = ((rand() >> 4) % vsat);


### PR DESCRIPTION
There are few places where time is used in x11iraf; this patch makes sure that `time_t` is used here instead of `long`. This makes x11iraf compilable with newer Linux distributions (which made the `time_t` transition to ensure working after 2038).

Also, we always use `time(NULL);`, not `time(0);` (argument is a pointer, not a number) or `time((long *)NULL);` (`NULL` pointers are valid for all pointer types without cast).