### PR TITLE
Correct argument order in xim_setMapping

### DIFF
--- a/ximtool/raster.c
+++ b/ximtool/raster.c
@@ -497,11 +497,11 @@ xim_resize (XimDataPtr xim, Widget w)
 			       &junk, &junk, &junk);
 		GtCreateRaster ((GtermWidget) w, fb->zoomras, zoomtype,
 				width, height, depth);
-		xim_setMapping ((FrameBufPtr)xim, NULL, frame, fb->dispmap,
+		xim_setMapping (xim, NULL, frame, fb->dispmap,
 		    fb->zoomras, 0, M_FILL);
 		if (!active) {
 		    GtDisableMapping ((GtermWidget)w, fb->dispmap, 0);
-		    xim_setMapping ((FrameBufPtr)xim, NULL, frame, fb->zoommap,
+		    xim_setMapping (xim, NULL, frame, fb->zoommap,
 			fb->raster, fb->zoomras, M_FILL);
 		    GtDisableMapping ((GtermWidget)w, fb->zoommap, 0);
 		}
@@ -750,11 +750,9 @@ fast:	    fb->zoomras = GtNextRaster (gt);
 		    fb->zoomras, GtServer, width, height, depth) < 0)
 		goto nice;
 
-	    xim_setMapping ((FrameBufPtr)xim, (XimDataPtr)fb,
-		frame, fb->zoommap = GtNextMapping(gt),
+	    xim_setMapping (xim, fb, frame, fb->zoommap = GtNextMapping(gt),
 		fb->raster, fb->zoomras, xim->autoscale ? M_ASPECT : M_UNITARY);
-	    xim_setMapping ((FrameBufPtr)xim, (XimDataPtr)fb,
-		frame, fb->dispmap = GtNextMapping(gt),
+	    xim_setMapping (xim, fb, frame, fb->dispmap = GtNextMapping(gt),
 		fb->zoomras, 0, M_FILL);
 
 	} else if (strcmp (memModel, "beNiceToServer") == 0) {
@@ -772,11 +770,9 @@ nice: 	    fb->zoomras = GtNextRaster (gt);
 		    fb->zoomras, GtClient, width, height, depth) < 0)
 		goto small;
 
-	    xim_setMapping ((FrameBufPtr)xim, (XimDataPtr)fb,
-		frame, fb->zoommap = GtNextMapping(gt),
+	    xim_setMapping (xim, fb, frame, fb->zoommap = GtNextMapping(gt),
 		fb->raster, fb->zoomras, xim->autoscale ? M_ASPECT : M_UNITARY);
-	    xim_setMapping ((FrameBufPtr)xim, (XimDataPtr)fb,
-		frame, fb->dispmap = GtNextMapping(gt),
+	    xim_setMapping (xim, fb, frame, fb->dispmap = GtNextMapping(gt),
 		fb->zoomras, 0, M_FILL);
 
 	} else if (strcmp (memModel, "small") == 0) {
@@ -795,8 +791,7 @@ small:	    fb->zoomras = 0;
 		    "xim_initFrame: creating 'small' model (0x%x)\n", 
 		    fb->zoomras);
 
-	    xim_setMapping ((FrameBufPtr)xim, (XimDataPtr)fb,
-		frame, fb->zoommap = GtNextMapping(gt),
+	    xim_setMapping (xim, fb, frame, fb->zoommap = GtNextMapping(gt),
 		fb->raster, fb->zoomras, xim->autoscale ? M_ASPECT : M_UNITARY);
 	    fb->dispmap = fb->zoommap;
 
@@ -1223,7 +1218,7 @@ xim_cursorMode (XimDataPtr xim, int state)
 /* XIM_SETMAPPING -- Set up a mapping between two rasters.
  */
 void
-xim_setMapping (FrameBufPtr fb, XimDataPtr xim, int frame, int mapping,
+xim_setMapping (XimDataPtr xim, FrameBufPtr fb, int frame, int mapping,
 		int src, int dst, int fill_mode)
 {
 	GtermWidget gt = (GtermWidget) xim->gt;

--- a/ximtool/ximtool.h
+++ b/ximtool/ximtool.h
@@ -716,7 +716,7 @@ void xim_initialize(XimDataPtr xim, int config, int nframes, int hardreset), xim
 int xim_shutdown (XimDataPtr xim);
 void xim_close(XimDataPtr xim), xim_initFrame(XimDataPtr xim, int frame, int nframes, FbConfigPtr config, char *memModel), xim_setFrame(XimDataPtr xim, int frame), xim_setRop(XimDataPtr xim, FrameBufPtr fb, int rop);
 void xim_setReferenceFrame(IoChanPtr chan, int frame), xim_setDisplayFrame(XimDataPtr xim, int frame);
-void xim_delFrame(XimDataPtr xim, int frame), xim_setMapping(FrameBufPtr fb, XimDataPtr xim, int frame, int mapping, int src, int dst, int fill_mode);
+void xim_delFrame(XimDataPtr xim, int frame), xim_setMapping(XimDataPtr xim, FrameBufPtr fb, int frame, int mapping, int src, int dst, int fill_mode);
 void xim_setZoom(XimDataPtr, FrameBufPtr, int, int, int, int, float, float,
 		 float, float, float, float, Boolean);
 void xim_setCursorPos(XimDataPtr, float, float);


### PR DESCRIPTION
Followp for #67; they were accidentally exchanged, because their declarations in K&R C were not in order:

```diff,C
 void
-xim_setMapping (xim, fb, frame, mapping, src, dst, fill_mode)
-register FrameBufPtr fb;
-register XimDataPtr xim;
-int frame;
-int mapping;
-int src, dst;
-int fill_mode;
+xim_setMapping (FrameBufPtr fb, XimDataPtr xim, int frame, int mapping,
+		int src, int dst, int fill_mode)
```

https://github.com/iraf-community/x11iraf/pull/67/commits/9df25d40d0495d7c8d6bc61f1d5cdc9fa505afc4#r1822809554
