### PR TITLE
Add Freedesktop desktop and appstream metainfo files

### DIFF
--- a/xgterm/community.iraf.xgterm.metainfo.xml
+++ b/xgterm/community.iraf.xgterm.metainfo.xml
@@ -1,0 +1,32 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<component type="desktop-application">
+  <id>community.iraf.xgterm</id>
+
+  <name>xgterm</name>
+  <summary>X11 Terminal emulator to work with IRAF</summary>
+  <url type="homepage">https://iraf-community.github.io/x11iraf</url>
+
+  <metadata_license>MIT</metadata_license>
+  <project_license>LicenseRef-IRAF=https://iraf-community.github.io/COPYRIGHT</project_license>
+
+  <description>
+    <p>
+      XGterm provides a Tek 4012 compatible graphics terminal
+      emulation for IRAF, plus a datastream driven widget server
+      capability using the Object Manager to provide full access to
+      the underlying toolkit and widget set. The Gterm graphics window
+      operates almost identically to the xterm Tek window, however
+      there are extensions for implementing full-screen cursors,
+      imaging, area fills, colors, graphics erasure, a &quot;status
+      line&quot; and so on.
+    </p>
+  </description>
+
+  <launchable type="desktop-id">xgterm.desktop</launchable>
+  <content_rating type="oars-1.0"/>
+  <screenshots>
+    <screenshot type="default"><image>
+      https://screenshots.debian.net/shrine/screenshot/19252/simage/large-5fee24cf783028ca8990ce07c6a2d0f2.png
+    </image></screenshot>
+  </screenshots>
+</component>

--- a/xgterm/xgterm.desktop
+++ b/xgterm/xgterm.desktop
@@ -1,0 +1,11 @@
+[Desktop Entry]
+Version=1.0
+Type=Application
+
+Name=XGTerm
+Comment=IRAF terminal emulator
+Categories=Science;Astronomy;
+Icon=xgterm
+Exec=xgterm
+
+StartupWMClass=XGterm

--- a/ximtool/.alias
+++ b/ximtool/.alias
@@ -1,5 +1,0 @@
-
-alias mx "c;make ; ./ximtool -gui ximtool-alt.gui zz.fits"
-alias x "c;./ximtool -gui ximtool-alt.gui zz.fits"
-alias z "c;(chdir gui; mkgui) ; ./ximtool -gui ximtool-alt.gui zz.fits"
-alias zz "c;(chdir gui; mkgui) ; make; ./ximtool -gui ximtool-alt.gui zz.fits"

--- a/ximtool/community.iraf.ximtool.metainfo.xml
+++ b/ximtool/community.iraf.ximtool.metainfo.xml
@@ -1,0 +1,32 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<component type="desktop-application">
+  <id>community.iraf.ximtool</id>
+
+  <name>ximtool</name>
+  <summary>Interactive image display program for the X Window System</summary>
+  <url type="homepage">https://iraf-community.github.io/x11iraf</url>
+
+  <metadata_license>MIT</metadata_license>
+  <project_license>LicenseRef-IRAF=https://iraf-community.github.io/COPYRIGHT</project_license>
+
+  <description>
+    <p>
+      Ximtool provides an image display capability to remote client
+      applications for IRAF using the standard imtool/iis image
+      display protocol. The image display server allows a number of
+      image frame buffers to be created and displayed. The client can
+      read and write data in these frame buffers. Any frame or
+      combination of frames can be displayed. Various display options
+      are provided, e.g., zoom and pan, flip about either axis, frame
+      blink, windowing of the display, and colortable enhancement.
+    </p>
+  </description>
+
+  <launchable type="desktop-id">ximtool.desktop</launchable>
+  <content_rating type="oars-1.0"/>
+  <screenshots>
+    <screenshot type="default"><image>
+      https://screenshots.debian.net/shrine/screenshot/19253/simage/large-34c804c61f34485fbc2762b319bc54f5.png
+    </image></screenshot>
+  </screenshots>
+</component>

--- a/ximtool/ximtool.desktop
+++ b/ximtool/ximtool.desktop
@@ -1,0 +1,11 @@
+[Desktop Entry]
+Version=1.0
+Type=Application
+
+Name=XImtool
+Comment=Astronomical Image Visualization Application
+Categories=Science;Astronomy;
+Icon=ximtool
+Exec=ximtool %F
+
+StartupWMClass=XImtool


### PR DESCRIPTION
These files are common for all Linux distributions, so it is useful to maintain them here.